### PR TITLE
Jinja2 import in objects fixed

### DIFF
--- a/sc/app/objects.py
+++ b/sc/app/objects.py
@@ -12,12 +12,13 @@ import xml.etree.ElementTree as ET
 import smtplib
 import datetime
 import time
-from jinja2 import Template
 from util import *
 from orm import *
 modules_dir = os.path.join(sc_dir(), 'modules')
 if modules_dir not in sys.path:
     sys.path += [modules_dir]
+    
+from jinja2 import Template
 import socks
 
 class ProductGrabber(object):


### PR DESCRIPTION
The import was performed before the modules folder was added to path.
This didn't create any issues with pip installed libraries, but failed
when modules were manually put together