### PR TITLE
Configurable web port, system check, services restart, UI updates

### DIFF
--- a/admin/Linux/restart_shakecast.sh
+++ b/admin/Linux/restart_shakecast.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+if [[ $UID != 0 ]]; then
+    echo "Please run this script with sudo:"
+    echo "sudo $0 $*"
+    exit 1
+fi
+
+echo "Stopping Shakecast..."
+
+python web_server_service.py stop
+python server_service.py stop
+
+echo "Starting Shakecast..."
+
+python web_server_service.py start &
+python server_service.py start &
+
+echo "Done."

--- a/admin/Linux/web_server_service.py
+++ b/admin/Linux/web_server_service.py
@@ -20,7 +20,7 @@ logging.basicConfig(
     format = '[ShakeCast - Web] %(levelname)-7.7s %(message)s'
 )
 
-from web_server import app
+from web_server import start
 
 class ShakecastWebServer(object):
     _svc_name_ = "sc_web_server"
@@ -47,7 +47,7 @@ class ShakecastWebServer(object):
     def main():
         logging.info(' ** Starting ShakeCast Web Server ** ')
         try:
-            app.run(host='0.0.0.0', port=80, threaded=True)
+            start()
 
         except Exception as e:
             logging.info('FAILED')

--- a/admin/Windows/restart_shakecast.cmd
+++ b/admin/Windows/restart_shakecast.cmd
@@ -1,0 +1,11 @@
+python "%userprofile%\Shakecast\admin\Windows\server_service.py" stop
+python "%userprofile%\Shakecast\admin\Windows\web_server_service.py" stop
+
+python "%userprofile%\Shakecast\admin\Windows\server_service.py" remove
+python "%userprofile%\Shakecast\admin\Windows\web_server_service.py" remove
+
+python "%userprofile%\Shakecast\admin\Windows\server_service.py" install
+python "%userprofile%\Shakecast\admin\Windows\web_server_service.py" install
+
+python "%userprofile%\Shakecast\admin\Windows\server_service.py" start
+python "%userprofile%\Shakecast\admin\Windows\web_server_service.py" start

--- a/admin/Windows/web_server_service.py
+++ b/admin/Windows/web_server_service.py
@@ -25,7 +25,7 @@ logging.basicConfig(
     format = '[ShakeCast - Web] %(levelname)-7.7s %(message)s'
 )
 
-from web_server import app
+from web_server import start
 
 class ShakecastServer (win32serviceutil.ServiceFramework):
     _svc_name_ = "sc_web_server"
@@ -60,7 +60,7 @@ class ShakecastServer (win32serviceutil.ServiceFramework):
     def main():
         logging.info(' ** Starting ShakeCast Web Server ** ')
         try:
-            app.run(host='0.0.0.0', port=80)
+            start()
 
         except Exception as e:
             exc_tb = sys.exc_info()[2]

--- a/sc/app/functions.py
+++ b/sc/app/functions.py
@@ -1299,7 +1299,7 @@ def system_test():
 
     for test in tests:
         try:
-            result = test['test']()
+            test['test']()
             results['pass'] += [test['name']]
         except Exception as e:
             results['fail'] += [test['name']]

--- a/sc/app/functions.py
+++ b/sc/app/functions.py
@@ -1291,11 +1291,14 @@ def smtp_test():
     msg['To'] = you
     m.send(msg=msg, you=you)
 
-def system_test():
+def system_test(add_tests=None):
     results = {'pass': [], 'fail': [], 'errors': []}
     tests = [{'name': 'url', 'test': url_test}, 
              {'name': 'db', 'test': db_test},
              {'name': 'smtp', 'test': smtp_test}]
+
+    if add_tests is not None:
+        tests += add_tests
 
     for test in tests:
         try:

--- a/sc/app/server.py
+++ b/sc/app/server.py
@@ -461,7 +461,8 @@ class Server(object):
         return {'status': 'finished',
                 'message': 'Stopping server...'}
 
-    def restart(self):
+    @staticmethod
+    def restart():
         """
         Stops the current ShakeCast system and starts a new one. Used
         after software updates or in case of error

--- a/sc/app/server.py
+++ b/sc/app/server.py
@@ -353,17 +353,17 @@ class Server(object):
             status = ''
             message = ''
             task_names = [task.name for task in self.queue]
-            if 'geo_json' not in task_names:
-                task = Task()
-                task.id = int(time.time() * 1000000)
-                task.func = f.geo_json
-                task.loop = True
-                task.interval = 60 * 60 * 12
-                task.db_use = True
-                task.name = 'geo_json'
+            # if 'geo_json' not in task_names:
+            #     task = Task()
+            #     task.id = int(time.time() * 1000000)
+            #     task.func = f.geo_json
+            #     task.loop = True
+            #     task.interval = 60 * 60 * 12
+            #     task.db_use = True
+            #     task.name = 'geo_json'
             
-                self.queue += [task]
-                message += 'Started monitoring earthquake feed \n'
+            #     self.queue += [task]
+            #     message += 'Started monitoring earthquake feed \n'
 
             if 'fast_geo_json' not in task_names:
                 task = Task()
@@ -460,6 +460,31 @@ class Server(object):
         logging.info('ShakeCast Server Stopped...')
         return {'status': 'finished',
                 'message': 'Stopping server...'}
+
+    def restart(self):
+        """
+        Stops the current ShakeCast system and starts a new one. Used
+        after software updates or in case of error
+        """
+        # get the admin directory:
+        split_sc_dir = sc_dir().split(os.sep)
+        split_admin_dir = split_sc_dir[:-1] + ['admin']
+
+        # determine which OS type we're on and which program to run
+        if os.sep == '/':
+            sys_type = 'Linux'
+            program = 'restart_shakecast.sh'
+            split_restart = split_admin_dir + [sys_type, program]
+            restart = 'sudo bash ' + os.path.normpath(os.sep.join(split_restart))
+        else:
+            sys_type = 'Windows'
+            program = 'restart_shakecast.cmd'
+            split_restart = split_admin_dir + [sys_type, program]
+            restart = os.path.normpath(os.sep.join(split_restart))
+        # concatinate the full restart command
+
+        # and run it
+        os.system(restart)
             
 if __name__ == '__main__':
     logging.info('start')
@@ -467,6 +492,7 @@ if __name__ == '__main__':
     # start shakecast
     sc_server.start_shakecast()
     
+    # catch crashes
     while sc_server.stop_server is False:
         sc_server.stop_loop = False
         sc_server.loop()

--- a/sc/conf/sc.json
+++ b/sc/conf/sc.json
@@ -1,9 +1,5 @@
 {
-    "Logging": {
-        "log_file": "sc.log", 
-        "log_level": "normal", 
-        "log_rotate": 3
-    }, 
+    "web_port": 80, 
     "DBConnection": {
         "username": "", 
         "retry_count": 0, 
@@ -28,13 +24,18 @@
     "Server": {
         "update": {
             "json_url": "https://raw.githubusercontent.com/usgs/shakecast/master/update.json", 
-            "db_version": 1, 
-            "update_version": "4.0.0b5", 
+            "db_version": 2, 
+            "update_version": "4.0.0b6", 
             "admin_notified": true, 
-            "software_version": "4.0.0b5"
+            "software_version": "4.0.0b6"
         }, 
         "DNS": "https://localhost", 
         "name": "ShakeCast"
+    }, 
+    "Logging": {
+        "log_file": "sc.log", 
+        "log_level": "normal", 
+        "log_rotate": 3
     }, 
     "gmap_key": "AIzaSyDLDpOUwK7PlOju_E7z02lEJOxgrtBIPkY", 
     "Proxy": {

--- a/sc/test/test.py
+++ b/sc/test/test.py
@@ -11,6 +11,18 @@ if path not in sys.path:
 from app.functions import *
 from app.task import Task
 
+class SystemTest(unittest.TestCase):
+    '''
+    System Test
+    '''
+    def test_systemTest(self):
+        '''
+        Test user run system tests
+        '''
+        result = system_test()
+        
+
+
 class TestProductGrabber(unittest.TestCase):
     '''
     Test functions for the ProductGrabber class
@@ -407,12 +419,18 @@ class TestFull(unittest.TestCase):
 
     def step17_CheckUpdate(self):
         s = SoftwareUpdater()
-        s.json_url = 'https://raw.githubusercontent.com/usgs/shakecast/update-feed/update_test.json'
+        s.json_url = os.path.normpath(delim.join(['file://', 
+                                                    sc_dir(), 
+                                                    'test', 
+                                                    'update_test.json']))
         s.check_update(testing=True)
     
     def step18_Update(self):
         s = SoftwareUpdater()
-        s.json_url = 'https://raw.githubusercontent.com/usgs/shakecast/update-feed/update_test.json'
+        s.json_url = os.path.normpath(delim.join(['file://', 
+                                                    sc_dir(), 
+                                                    'test', 
+                                                    'update_test.json']))
         s.update(testing=True)
 
     def step19_NotifyAdmin(self):

--- a/sc/test/test.py
+++ b/sc/test/test.py
@@ -304,6 +304,16 @@ class TestFull(unittest.TestCase):
                 f = create_fac(grid=grid)
                 f.name = 'TEST FAC'
                 session.add(f)
+
+                f = create_fac(grid=grid)
+                f.name = 'GREY FAC'
+                f.grey = 0
+                f.green = 10
+                f.yellow = 11
+                f.orange = 12
+                f.red = 13
+                session.add(f)
+                
             session.commit()
 
         grid.in_grid(facility=f)

--- a/sc/test/test.py
+++ b/sc/test/test.py
@@ -19,9 +19,13 @@ class SystemTest(unittest.TestCase):
         '''
         Test user run system tests
         '''
+        # all these tests should pass
         result = system_test()
-        
+        self.assertTrue(result['message']['success'])
 
+        # insert a test that raises an error
+        result = system_test(add_tests=[{'name': 'fail', 'test': fail_test}])
+        self.assertFalse(result['message']['success'])
 
 class TestProductGrabber(unittest.TestCase):
     '''
@@ -313,7 +317,7 @@ class TestFull(unittest.TestCase):
                 f.orange = 12
                 f.red = 13
                 session.add(f)
-                
+
             session.commit()
 
         grid.in_grid(facility=f)
@@ -933,6 +937,13 @@ def create_user(group_str=None, email=None):
     user.group_string = group_str
 
     return user
+
+def fail_test():
+    '''
+    A test to inject into the system_test function forcing it to run
+    its fail routines
+    '''
+    raise ValueError('This test fails on purpose')
 
 if __name__ == '__main__':
     

--- a/sc/test/update_test.json
+++ b/sc/test/update_test.json
@@ -1,0 +1,10 @@
+{
+    "updates": [
+        {"version": "500.0.0b5",
+        "info": "TEST UPDATE",
+        "files": [
+            {"url": "https://raw.githubusercontent.com/usgs/shakecast/master/sc/app/functions.py",
+             "path": "sc/app/functions-test.py"}
+        ]}
+    ]
+}

--- a/sc/ui.py
+++ b/sc/ui.py
@@ -119,7 +119,7 @@ class UI(object):
             self.conns += [self.conn]
             
             sent = True
-        except Exception as e:
+        except Exception:
             sent = False
 
         return sent

--- a/sc/ui.py
+++ b/sc/ui.py
@@ -86,67 +86,50 @@ class UI(object):
         Sends an input message to the Server. This is where the
         hard-wired commands are translated into the Server API
         """
-        
-        sent = False
-        while sent is False:
-            try:
-                
-                #######################################################
-                ################### API Translation ###################
-                
-                if msg == 'shutdown' and self.port != 80 and self.port != 5000:
-                    to_server = "{'shutdown': {'func': self.shutdown}}"
-                elif msg == 'info':
-                    to_server = "{'info': {'func': self.info}}"
-                elif msg == 'exit':
-                    self._get_message = 'last'
-                    self.stop_ui = 'last'
-                    to_server = "{'ui_exit': {'func': self.ui_exit}}"
-                elif 'stop_task' in msg:
-                    msg = msg.split(' ')
-                    to_server = "{'stop_task(%s)': \
-                                        {'func': self.stop_task, \
-                                         'args_in': {'task_name': '%s'}}}" % (msg[1],
-                                                                              msg[1])
-                elif msg == 'start':
-                    to_server = "{'start_shakecast': {'func': self.start_shakecast}}"
-                elif msg == 'stop':
-                    to_server = "{'stop_shakecast': {'func': self.stop_shakecast}}"
-                else:
-                    to_server = msg
-                    
-                self.connect_to_server()    
-                self.conn.send(to_server)
-                self.conn.shutdown(1)
-                
-                self.conns += [self.conn]
-                
-                sent = True
-            except Exception:
-                sent = False
-
-                #if self.stop_ui is False:
-                #    print 'Failed to connect to server'
-                #    self.start_server()
-                #    
-                #    time.sleep(2)
-                #    print 'Resending message...'
-                #else:
-                #    print 'Closing UI...'
-                #    
-                #    # The server is down, so close messaging down
-                #    # without an exit message
-                #    self._get_message = False
-                #    sent = True
+        try:
             
-        
+            #######################################################
+            ################### API Translation ###################
+            
+            if msg == 'shutdown' and self.port != 80 and self.port != 5000:
+                to_server = "{'shutdown': {'func': self.shutdown}}"
+            elif msg == 'info':
+                to_server = "{'info': {'func': self.info}}"
+            elif msg == 'exit':
+                self._get_message = 'last'
+                self.stop_ui = 'last'
+                to_server = "{'ui_exit': {'func': self.ui_exit}}"
+            elif 'stop_task' in msg:
+                msg = msg.split(' ')
+                to_server = "{'stop_task(%s)': \
+                                    {'func': self.stop_task, \
+                                        'args_in': {'task_name': '%s'}}}" % (msg[1],
+                                                                            msg[1])
+            elif msg == 'start':
+                to_server = "{'start_shakecast': {'func': self.start_shakecast}}"
+            elif msg == 'stop':
+                to_server = "{'stop_shakecast': {'func': self.stop_shakecast}}"
+            else:
+                to_server = msg
+                
+            self.connect_to_server()    
+            self.conn.send(to_server)
+            self.conn.shutdown(1)
+            
+            self.conns += [self.conn]
+            
+            sent = True
+        except Exception as e:
+            sent = False
+
         return sent
 
     def connect_to_server(self):
         """
         Attempt to connect to the server
         """
-        self.conn = socket.socket()
+        self.conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.conn.settimeout(3)
         self.conn.connect(('localhost', self.port))
         
     def get_message(self):
@@ -230,25 +213,9 @@ class UI(object):
         try:
             self.connect_to_server()
             return True
-            #print 'connected'
         except:
             return False
-            #print 'None available.'
-    
-        
-    # def start_server(self):
-    #     """
-    #     Starts a Server if there isn't one running
-    #     """
-    #     print 'Starting server...'
-    #     try:
-    #         sc_server = Server()
-    #         sc_server.silent = True
-    #         sc_server.ui_open = True
-    #         server_thread = New_Thread(func=sc_server.loop)
-    #         server_thread.start()
-    #     except:
-    #         print 'failed'
+
         
         
 if __name__ == '__main__':

--- a/sc/view/app/shakecast-admin/pages/config/config.component.html
+++ b/sc/view/app/shakecast-admin/pages/config/config.component.html
@@ -128,6 +128,6 @@
     </div>
 </div>
 
-<h1 class="button save" (click)="saveConfigs()">SAVE</h1>
-<h1 class="button reset" (click)="resetConfigs()">RESET</h1>
-
+<h1 class="button save" (click)="saveConfigs()">Save</h1>
+<h1 class="button reset" (click)="resetConfigs()">Reset</h1>
+<h1 class="button" (click)="confService.systemTest()">Run a System Test</h1>

--- a/sc/view/app/shakecast-admin/pages/config/config.service.ts
+++ b/sc/view/app/shakecast-admin/pages/config/config.service.ts
@@ -38,5 +38,15 @@ export class ConfigService {
         ).subscribe((result: any) => {
             this.notService.success('Success!', 'New Configurations Saved');
         });
-    }    
+    }
+
+    systemTest() {
+        let headers = new Headers();
+        this.notService.success('System Test', 'System test starting...');
+        this._http.get('/admin/system-test')
+            .map((result: Response) => result.json())
+            .subscribe((result: any) => {
+                this.loadingData.next(false);
+            });
+    }
 }

--- a/sc/view/app/shakecast-admin/pages/config/config.service.ts
+++ b/sc/view/app/shakecast-admin/pages/config/config.service.ts
@@ -45,7 +45,10 @@ export class ConfigService {
         this.notService.success('System Test', 'System test starting...');
         this._http.get('/admin/system-test')
             .map((result: Response) => result.json())
-            .subscribe((result: any) => {
+            .subscribe((result: boolean) => {
+                if (!result) {
+                    this.notService.error('System Test Failed', 'Unable to reach the ShakeCast server')
+                }
                 this.loadingData.next(false);
             });
     }

--- a/sc/view/app/shakecast-admin/pages/facilities/facilities.component.ts
+++ b/sc/view/app/shakecast-admin/pages/facilities/facilities.component.ts
@@ -41,10 +41,12 @@ export class FacilitiesComponent implements OnInit, OnDestroy, AfterViewInit {
     }
 
     ngAfterViewInit() {
+        /*
         this.facService.clearMap()
         if (this.facList.length > 0) {
             this.facService.plotFac(this.facList[0]);
         }
+        */
     }
 
     toggleLeft() {

--- a/sc/view/app/shakecast-admin/pages/facilities/facility-info/facility-info.component.css
+++ b/sc/view/app/shakecast-admin/pages/facilities/facility-info/facility-info.component.css
@@ -1,15 +1,15 @@
 .header {
-    border-bottom: 5px solid #AED8FA;
+    border-bottom: 5px solid #55aaee;
     color: white;
 }
 
 .info-header {
     color: white;
+    margin-bottom: 0;
 }
 
 .desc {
     text-align: center;
-    font-style: italic;
     background: #efefef;
     padding: 10px;
     margin: 10px;
@@ -21,6 +21,33 @@
     color: black;
 }
 
+.location {
+    color: white;
+    font-style: italic;
+
+}
+
+.colors-table th {
+    padding: 5px;
+    color:white;
+    border-radius: 5px;
+    margin: 3px;
+}
+
+.fragility h2 {
+    margin: 10px 0 5px 0;
+    color: white;
+}
+
+.fragility p {
+    color:white;
+    margin:0;
+}
+
+.type {
+    color: white;
+    margin: 0 0 20px 0;
+}
 /*
 
 .info-content {

--- a/sc/view/app/shakecast-admin/pages/facilities/facility-info/facility-info.component.html
+++ b/sc/view/app/shakecast-admin/pages/facilities/facility-info/facility-info.component.html
@@ -1,14 +1,39 @@
 <div class="fac-info">
     <div class="info-content" *ngIf="facility">
         <div class="header">
-            <h2 class="info-header">{{ facility.name }}</h2>
-            <p class="desc">{{ facility.description ? facility.description : 'No Description' }}</p>
+            <h1 class="info-header">{{ facility.name }}</h1>
+            <p class="type">Type: {{ facility.facility_type }}</p>
+            <p class="desc" *ngIf="facility.description">{{ facility.description }}</p>
+            <p class="location">{{ (facility.lat_max + facility.lat_min) / 2 }}, {{ (facility.lon_max + facility.lon_min) / 2 }}
         </div>
 
-        <h1 class="info-header">Shaking History</h1>
+        <div class="fragility">
+            <h2>Fagility</h2>
+            <p>Metric: {{ facility.metric }}</p>
+            <table class="colors-table" style="width:100%;text-align:center">
+                <tr>
+                    <th *ngIf="facility.green" style="background-color:green;">
+                        {{ facility.green }}
+                    </th>
+                    <th *ngIf="facility.yellow" style="background-color:gold;">
+                        {{ facility.yellow }}
+                    </th>
+                    <th *ngIf="facility.orange" style="background-color:orange;">
+                        {{ facility.orange }}
+                    </th>
+                    <th *ngIf="facility.red" style="background-color:red;">
+                        {{ facility.red }}
+                    </th>
+                </tr>
+            </table>
+        </div>
 
-        <div class="eq-list">
-            <earthquake-list></earthquake-list>
+        <div class="shaking" *ngIf="eqService.current.length > 0">
+            <h2 class="info-header">Shaking History</h2>
+
+            <div class="eq-list">
+                <earthquake-list></earthquake-list>
+            </div>
         </div>
     </div>
 </div>

--- a/sc/view/app/shakecast-admin/pages/facilities/facility-list.component.ts
+++ b/sc/view/app/shakecast-admin/pages/facilities/facility-list.component.ts
@@ -62,14 +62,12 @@ export class FacilityListComponent implements OnInit, OnDestroy {
             }
 
             if ((this.facilityData.length > 0) && (this._router.url === '/shakecast-admin/facilities')) {
-                this.facService.clearMap();
                 if (!this.selectedFacs) {
                     this.selectedFacs.push(this.facilityData[0]);
                 }
 
                 this.facService.setFacInfo(this.facilityData[0]);
                 this.facilityData[0].selected = 'yes';
-                this.plotFac(this.facilityData[0]);
             }
         }));
 

--- a/sc/view/app/shakecast/pages/dashboard/dashboard.component.ts
+++ b/sc/view/app/shakecast/pages/dashboard/dashboard.component.ts
@@ -21,9 +21,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
     public earthquakeData: any = [];
     private subscriptions: any[] = [];
 
-    public showBottom: string = 'hidden';
+    public showBottom: string = 'shown';
     public showLeft: string = 'hidden';
-    public showRight: string = 'hidden';
+    public showRight: string = 'shown';
 
     constructor(private eqService: EarthquakeService,
                 private facService: FacilityService,

--- a/sc/view/app/shakecast/pages/earthquakes/earthquake-list.component.ts
+++ b/sc/view/app/shakecast/pages/earthquakes/earthquake-list.component.ts
@@ -76,6 +76,7 @@ export class EarthquakeListComponent implements OnInit, OnDestroy {
 
     ngOnDestroy() {
         this.earthquakeData = [];
+        this.eqService.current = [];
         this.endSubscriptions()
     }
 

--- a/sc/view/app/shared/css/panels.css
+++ b/sc/view/app/shared/css/panels.css
@@ -79,7 +79,8 @@
 
 .bottom-panel .toggle-click .arrow-icon {
     position: absolute;
-    transform: translateY(-100%) rotate(45deg);
+    transform: translateX(110%) translateY(-95%) rotate(45deg);
+    right: 50%;
 }
 
 .arrow-icon:before {

--- a/sc/view/app/shared/info/info.component.css
+++ b/sc/view/app/shared/info/info.component.css
@@ -102,7 +102,3 @@
 p {
     font-size: .4em;
 }
-
-a {
-    color: #55aaee
-}

--- a/sc/web_server.py
+++ b/sc/web_server.py
@@ -718,7 +718,6 @@ def new_not_template(name):
 
     return json.dumps(True)
 
-
 @app.route('/admin/get/inventory')
 @admin_only
 @login_required
@@ -759,6 +758,14 @@ def get_inventory():
     
     Session.remove()    
     return facilities_json
+
+@app.route('/admin/system-test')
+@admin_only
+@login_required
+def system_test():
+    ui.send("{'System Test': {'func': f.system_test, 'args_in': {}, 'db_use': True, 'loop': False}}")
+
+    return json.dumps(True)
 
 def shutdown_server():
     func = request.environ.get('werkzeug.server.shutdown')

--- a/sc/web_server.py
+++ b/sc/web_server.py
@@ -799,4 +799,5 @@ if __name__ == '__main__':
             # run in debug mode
             app.run(host='0.0.0.0', port=5000, debug=True, threaded=True)
     else:
-        app.run(host='0.0.0.0', port=80, threaded=True)
+        sc = SC()
+        app.run(host='0.0.0.0', port=sc.dict['web_port'], threaded=True)

--- a/sc/web_server.py
+++ b/sc/web_server.py
@@ -617,6 +617,7 @@ def software_update():
     s = SoftwareUpdater()
     if request.method == 'POST':
         s.update()
+        ui.send("{'Restart': {'func': self.restart, 'args_in': {}, 'db_use': True, 'loop': False}}")
 
     update_required, notify, update_info = s.check_update()
     return json.dumps({'required': update_required,
@@ -778,6 +779,11 @@ def shutdown():
     shutdown_server()
     return 'Server shutting down...'
 
+@app.route('/admin/restart')
+def restart():
+    ui.send("{'Restart': {'func': self.restart, 'args_in': {}, 'db_use': True, 'loop': False}}")
+    return json.dumps(True)
+
 @app.errorhandler(404)
 def page_not_found(error):
     return render_template('index.html')
@@ -800,11 +806,14 @@ def get_file_type(file_name):
     elif ext in ['xml']:
         return 'xml'
 
+def start():
+    sc = SC()
+    app.run(host='0.0.0.0', port=sc.dict['web_port'], threaded=True)
+
 if __name__ == '__main__':
     if len(sys.argv) > 1:
         if sys.argv[1] == '-d':
             # run in debug mode
             app.run(host='0.0.0.0', port=5000, debug=True, threaded=True)
     else:
-        sc = SC()
-        app.run(host='0.0.0.0', port=sc.dict['web_port'], threaded=True)
+        start()

--- a/sc/web_server.py
+++ b/sc/web_server.py
@@ -781,8 +781,8 @@ def shutdown():
 
 @app.route('/admin/restart')
 def restart():
-    ui.send("{'Restart': {'func': self.restart, 'args_in': {}, 'db_use': True, 'loop': False}}")
-    return json.dumps(True)
+    result = ui.send("{'Restart': {'func': self.restart, 'args_in': {}, 'db_use': True, 'loop': False}}")
+    return json.dumps(result)
 
 @app.errorhandler(404)
 def page_not_found(error):


### PR DESCRIPTION
* Configurable web port only fully functional on port 80 and 5000

Admin can run a system check from their "settings". This hits the web, database, and their SMTP server.

A ShakeCast system restart has been implemented and is executed by the server. This should allow users to update their instances without sshing into their system