### PR TITLE
Roll versions

### DIFF
--- a/build_update.py
+++ b/build_update.py
@@ -2,8 +2,8 @@ import os
 import json
 from sc.app.util import SC
 
-COMMIT = 'e0249bfd45a0e2b38d854784c967aa53f24fafb4'
-GITROOT = 'https://raw.githubusercontent.com/usgs/shakecast/master/'
+COMMIT = 'af54dcaa7fa82bc18eef75af180942efe4199937'
+GITROOT = 'https://raw.githubusercontent.com/usgs/shakecast/master-dist/'
 
 def get_file_names():
     # git list of changed files from specific commit

--- a/sc/conf/sc.json
+++ b/sc/conf/sc.json
@@ -26,9 +26,9 @@
         "update": {
             "json_url": "https://raw.githubusercontent.com/usgs/shakecast/master/update.json", 
             "db_version": 1, 
-            "update_version": "4.0.0", 
+            "update_version": "4.0.1", 
             "admin_notified": true, 
-            "software_version": "4.0.0"
+            "software_version": "4.0.1"
         }, 
         "DNS": "https://localhost", 
         "name": "ShakeCast"


### PR DESCRIPTION
And change update url to master-dist. This allows us to leave compiled code out of the master branch.