### PR TITLE
Fix 100% red weight bug

### DIFF
--- a/sc/app/orm.py
+++ b/sc/app/orm.py
@@ -866,7 +866,7 @@ class ShakeMap(Base):
         alert_level = None
         if len(self.facility_shaking) > 0:
             insp_val = self.facility_shaking[0].weight
-            alert_levels = ['gray', 'green', 'yellow', 'orange', 'red']
+            alert_levels = ['gray', 'green', 'yellow', 'orange', 'red', 'red']
             alert_level = alert_levels[int(floor(insp_val))]
 
         return alert_level

--- a/sc/tests/orm.py
+++ b/sc/tests/orm.py
@@ -1,0 +1,22 @@
+import unittest
+
+from sc.app.orm import *
+
+class TestShakeMap(unittest.TestCase):
+    def test100Red(self):
+        sm = ShakeMap()
+        fs = FacilityShaking(
+            shakemap = sm,
+            weight = 5,
+            gray = 0,
+            green = 0,
+            yellow = 0,
+            orange = 0,
+            red = 100
+        )
+
+        alert_level = sm.get_alert_level()
+        self.assertEqual(alert_level, 'red')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
closes #309 

Fix bug that prevents processing of shakemaps which inflect a perfect complete damage state