### PR TITLE
Installer and windows paths update

### DIFF
--- a/nsis.nsi
+++ b/nsis.nsi
@@ -31,12 +31,21 @@ Section "Install ShakeCast" IDOK
     SetOutPath $INSTDIR
 
     # set environment variable for shakecast home
-    EnVar::AddValue "SC_HOME" "$PROFILE/.shakecast"
+    ; include for some of the windows messages defines
+    !include "winmessages.nsh"
+    ; HKLM (all users) vs HKCU (current user) defines
+    !define env_hklm 'HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"'
+    !define env_hkcu 'HKCU "Environment"'
+    ; set variable for local machine
+    WriteRegExpandStr ${env_hklm} SC_HOME "$PROFILE\.shakecast"
+    ; and current user
+    WriteRegExpandStr ${env_hkcu} SC_HOME "$PROFILE\.shakecast"
+    ; make sure windows knows about the change
+    SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
 
     DetailPrint "Extracting Files into Installation Directory" 
-
     # specify files to go into the installation directory path
-    File /r "*"
+    File "*"
 
     # Uninstaller - See function un.onInit and section "uninstall" for configuration
 	writeUninstaller "$INSTDIR\uninstall.exe"
@@ -52,17 +61,29 @@ Section "Python Installation"
     # install the windows extensions
     File "..\requirements\pywin32-224.win32-py2.7.exe"
     ExecWait 'C:\Python27\Scripts\easy_install.exe "$INSTDIR\pywin32-224.win32-py2.7.exe"'
-    
 
+    DetailPrint "Python is ready..."
 SectionEnd
 
 Section "ShakeCast installation"
     DetailPrint "Installing ShakeCast"
 
-    ExecWait "C:\Python27\python.exe -m pip install usgs-shakecast"
-    ExecWait "C:\Python27\python.exe -m shakecast.app.windows.set_paths"
-    ExecWait "C:\Python27\python.exe -m shakecast start"
-    DetailPrint "Finishing up Installation"
+    ExecDos::exec /DETAILED "C:\Python27\python.exe -m pip install usgs-shakecast"
+    ExecDos::exec /DETAILED "C:\Python27\python.exe -m pip install usgs-shakecast --upgrade"
+
+    ExecDos::exec /DETAILED "C:\Python27\python.exe -m shakecast.app.startup"
+    ExecDos::exec /DETAILED "C:\Python27\python.exe -m shakecast.app.windows.set_paths"
+    ExecDos::exec /DETAILED "C:\Python27\python.exe -m shakecast.app.windows install"
+
+    ExecDos::exec /DETAILED "C:\Python27\python.exe -m shakecast start"
+    ExecDos::exec /DETAILED "C:\Python27\python.exe -m shakecast stop"
+    Sleep 10000
+    ExecDos::exec /DETAILED "C:\Python27\python.exe -m shakecast start"
+
+    # make a link to the python package from the install directory
+    CreateShortCut "$INSTDIR\shakecast.lnk" "C:\Python27\Lib\site-packages\shakecast"
+    CreateShortCut "$INSTDIR\user-data.lnk" "$PROFILE\.shakecast"
+    DetailPrint "Finishing up Installation..."
 SectionEnd
 
 # Uninstaller
@@ -79,18 +100,20 @@ functionEnd
  
 section "uninstall"
 
-    ExecWait "c:\python27\python.exe -m shakecast stop"
-    ExecWait "c:\python27\python.exe -m shakecast uninstall"
+    ExecDos::exec /DETAILED "C:\Python27\python.exe -m shakecast stop"
+    ExecDos::exec /DETAILED "C:\Python27\python.exe -m shakecast.app.windows uninstall"
+    ExecDos::exec /DETAILED "C:\Python27\python.exe -m shakecast.app.windows.set_paths remove"
+    ExecDos::exec /DETAILED "C:\Python27\Scripts\pip.exe uninstall pywin32 -y"
     ExecWait '"$SYSDIR\msiExec" /x "$INSTDIR\python-2.7.13.msi"'
 
 	# Remove files
 	delete $INSTDIR\*
 
-    # Remove ShakeCast directories safely
-    rmDir /r $INSTDIR\admin
-    rmDir /r $INSTDIR\shakecast
-    rmDir /r $INSTDIR\appveyor
-    rmDir /r $INSTDIR\.git
+    # Remove data directory
+    rmDir /r "$PROFILE\.shakecast"
+
+    # Remove python
+    rmDir /r "C:\Python27"
 
 	# Always delete uninstaller as the last action
 	delete $INSTDIR\uninstall.exe

--- a/shakecast/app/windows/set_paths.py
+++ b/shakecast/app/windows/set_paths.py
@@ -7,17 +7,33 @@ REQUIRED_PATHS = ['C:\Python27',
 
 def add_paths(system_path_lst):
     paths = REQUIRED_PATHS + system_path_lst
-    return set(paths)
+    return paths
+
+def remove_paths(system_path_lst):
+    paths = []
+    for path in system_path_lst:
+        if path not in REQUIRED_PATHS and path:
+            paths.append(path)
+
+    return paths
 
 def get_path():
     path = os.environ.get('PATH')
     return path.split(';')
 
 def main():
-    path = get_path()
-    path = add_paths(path)
-    path = ';'.join(path)
+    action = 'add'
+    if len(sys.argv) > 1:
+        action = sys.argv[1]
 
+    path = get_path()
+    if action == 'add':
+        path = add_paths(path)
+    if action == 'remove':
+        path = remove_paths(path)
+
+    path = set(path)
+    path = ';'.join(path)
     save_path(path)
 
 def save_path(path):


### PR DESCRIPTION
closes #179 
closes #100 
closes #227 
closes #326 

Setting SC_HOME environment variable
Using shortcuts to actual python package and shakecast-home instead of including code in package
Install tries to upgrade pip package if it exists
Uninstall removes ShakeCast, Python, and pywin32, and windows paths