### PR TITLE
Filtering facilities by group specifications

### DIFF
--- a/shakecast/app/notifications/builder.py
+++ b/shakecast/app/notifications/builder.py
@@ -40,8 +40,14 @@ class NotificationBuilder(object):
         shakemap.sort_facility_shaking(config['table'].get('sort', 'weight'))
 
         if notification:
-            facility_shaking = filter(lambda x: notification.group in x.facility.groups, shakemap.facility_shaking)
-            fac_details = shakemap.get_impact_summary(notification.group)
+            group = notification.group
+            scenario = True if shakemap.type == 'scenario' else False
+            alert_levels = group.get_alert_levels(scenario)
+            facility_shaking = filter(
+                lambda x: group in x.facility.groups and x.alert_level in alert_levels,
+                shakemap.facility_shaking
+            )
+            fac_details = shakemap.get_impact_summary(group)
         else:
             facility_shaking = shakemap.facility_shaking
             fac_details = shakemap.get_impact_summary()

--- a/shakecast/app/orm/objects.py
+++ b/shakecast/app/orm/objects.py
@@ -694,8 +694,14 @@ class Group(Base):
     def get_alert_levels(self, scenario=False):
         specs = self._get_specs('damage', scenario=scenario)
 
-        return [spec.inspection_priority.lower() for spec in specs
+        alert_levels = [spec.inspection_priority.lower() for spec in specs
                 if spec is not None]
+        
+        # allow gray, grey mixup
+        if 'gray' in alert_levels or 'grey' in alert_levels:
+            alert_levels += ['grey', 'gray']
+        
+        return alert_levels
 
     def get_scenario_alert_levels(self):
         specs = self._get_specs('damage', scenario=True)

--- a/shakecast/app/orm/objects.py
+++ b/shakecast/app/orm/objects.py
@@ -691,8 +691,8 @@ class Group(Base):
 
         return False
 
-    def get_alert_levels(self):
-        specs = self._get_specs('damage')
+    def get_alert_levels(self, scenario=False):
+        specs = self._get_specs('damage', scenario=scenario)
 
         return [spec.inspection_priority.lower() for spec in specs
                 if spec is not None]

--- a/shakecast/templates/inspection/default.html
+++ b/shakecast/templates/inspection/default.html
@@ -108,7 +108,7 @@
                 {% endif %}
 
                 <br>
-                Total number of bridges analyzed: <b>{{ fac_details.all }}</b>
+                Total number of facilities analyzed: <b>{{ fac_details.all }}</b>
                 <br>
                 Summary by impact rank:
             </font>

--- a/shakecast/tests/inventory.py
+++ b/shakecast/tests/inventory.py
@@ -127,6 +127,8 @@ class TestImport(unittest.TestCase):
                 self.assertTrue(group.gets_notification('new_event', scenario=True))
                 self.assertTrue(group.gets_notification('damage', scenario=True))
                 self.assertTrue('green' in group.get_scenario_alert_levels())
+                self.assertTrue('gray' in group.get_alert_levels(scenario=True))
+                self.assertTrue('grey' in group.get_alert_levels(scenario=True))
 
             self.assertEqual('Ex1', group.updated_by)
         


### PR DESCRIPTION
closes #465 

Groups without a 'gray' inspection specification should have all gray facilities filtered out of inspection notifications