### PR TITLE
Product generation, notification, and logging update

### DIFF
--- a/shakecast/app/eventprocessing.py
+++ b/shakecast/app/eventprocessing.py
@@ -15,11 +15,9 @@ from .orm import (
     Notification,
     ShakeMap
 )
-from .products.geojson import generate_impact_geojson
-import sc_logging as logging
 from .util import Clock, SC, DAY
 from .notifications.notifications import new_event_notification, inspection_notification
-
+import sc_logging as logging
 
 def can_process_event(event, scenario=False):
     # check if we should wait until daytime to process
@@ -206,7 +204,7 @@ def process_events(events=None, session=None, scenario=False):
                     'log': message to be added to ShakeCast log
                            and should contain info on error}
     '''
-    logging.info('Picked up {} new events.'
+    logging.info('Picked up {} new events. {}'.format([event.event_id for event in events])
             .format(len(events)))
     if events:
         all_groups_affected = set([])
@@ -313,14 +311,6 @@ def process_shakemaps(shakemaps=None, session=None, scenario=False):
             session.commit()
             continue
 
-        # send out new events and create inspection notifications
-        new_notifications = create_inspection_notifications(
-            groups_affected, shakemap, scenario)
-
-        session.add_all(new_notifications)
-        session.commit()
-
-        logging.info('Creating {} new inspection notifications'.format(len(new_notifications)))
         # get a set of all affected facilities
         affected_facilities = (session.query(Facility)
                                .filter(Facility.in_grid(grid))
@@ -348,83 +338,21 @@ def process_shakemaps(shakemaps=None, session=None, scenario=False):
             session.commit()
             continue
 
-        # grab new notifications, and any that might have failed to send
-        notifications = (session.query(Notification)
-                         .filter(Notification.shakemap == shakemap)
-                         .filter(Notification.notification_type == 'DAMAGE')
-                         .filter(Notification.status == 'created')
-                         .all())
+        # send out new events and create inspection notifications
+        new_notifications = create_inspection_notifications(
+            groups_affected, shakemap, scenario)
 
-        if notifications:
-            # send inspection notifications for the shaking levels we
-            # just computed
-            for n in notifications:
-                # generate pdf for specific group
-                generate_local_products(n.group, n.shakemap, session=session)
-
-                logging.info('Generating inspection notification {}'.format(n))
-                inspection_notification(notification=n,
-                                        scenario=scenario,
-                                        session=session)
-                logging.info('Done with inspection notification.')
-
-        shakemap.mark_processing_finished()
-        if scenario is True:
-            shakemap.status = 'scenario'
+        session.add_all(new_notifications)
         session.commit()
 
-        # generate system level products
-        logging.info('Generating geojson product...')
-        generate_impact_geojson(shakemap, save=True)
-        logging.info('Done.')
+        logging.info('Creating {} new inspection notifications'.format(len(new_notifications)))
+
+        shakemap.mark_processing_finished()
+        session.commit()
+
 
         logging.info('Shakemap processing finished.')
     return shakemaps
-
-
-@dbconnect
-def generate_local_products(group, shakemap, session=None):
-    logging.info('Generating local products...')
-    if group.product_string is not None:
-        local_product_names = group.product_string.split(',')
-        product_types = session.query(LocalProductType).filter(
-            LocalProductType.name.in_(local_product_names)).all()
-
-        for product_type in product_types:
-            # check if product exists
-            product = (session.query(LocalProduct)
-                    .filter(LocalProduct.group == group)
-                    .filter(LocalProduct.shakemap == shakemap)
-                    .filter(LocalProduct.product_type == product_type).first())
-
-            if not product:
-                product = LocalProduct(
-                    group=group,
-                    shakemap=shakemap,
-                    product_type=product_type
-                )
-
-                product.name = (product_type.file_name or
-                        '{}_impact.{}'.format(group.name, product_type.type))
-
-            try:
-                if (product.finish_timestamp and
-                        product.finish_timestamp > product.shakemap.begin_timestamp):
-                    continue
-                
-                logging.info('Generating product: {}, for shakemap: {}-{}, for group: {}'
-                        .format(product.product_type.name, shakemap.shakemap_id, shakemap.shakemap_version, group.name))
-                product.generate()
-                logging.info('Done.')
-                product.error = None
-            except Exception as e:
-                logging.info('Product generation error: {}'.format(str(e)))
-                product.error = str(e)
-
-            logging.info('Done generating products.')
-            product.finish_timestamp = time.time()
-            session.add(product)
-        session.commit()
 
 
 @dbconnect

--- a/shakecast/app/eventprocessing.py
+++ b/shakecast/app/eventprocessing.py
@@ -17,7 +17,7 @@ from .orm import (
 )
 from .util import Clock, SC, DAY
 from .notifications.notifications import new_event_notification, inspection_notification
-import sc_logging as logging
+from .sc_logging import server_logger as logging
 
 def can_process_event(event, scenario=False):
     # check if we should wait until daytime to process

--- a/shakecast/app/eventprocessing.py
+++ b/shakecast/app/eventprocessing.py
@@ -204,9 +204,9 @@ def process_events(events=None, session=None, scenario=False):
                     'log': message to be added to ShakeCast log
                            and should contain info on error}
     '''
-    logging.info('Picked up {} new events. {}'.format([event.event_id for event in events])
-            .format(len(events)))
     if events:
+        logging.info('Picked up {} new events. {}'
+            .format(len(events), [event.event_id for event in events]))
         all_groups_affected = set([])
         for event in events:
             if can_process_event(event, scenario) is False:

--- a/shakecast/app/functions.py
+++ b/shakecast/app/functions.py
@@ -14,5 +14,5 @@ from inventory import (
 )
 from productdownload import geo_json, download_scenario
 from productgeneration import create_products
-from notifications.notifications import send_inspection_notifications
+from notifications.notifications import inspection_notification_service
 from servertestfunctions import system_test

--- a/shakecast/app/functions.py
+++ b/shakecast/app/functions.py
@@ -13,4 +13,6 @@ from inventory import (
     import_user_xml
 )
 from productdownload import geo_json, download_scenario
+from productgeneration import create_products
+from notifications.notifications import send_inspection_notifications
 from servertestfunctions import system_test

--- a/shakecast/app/linux/server_service.py
+++ b/shakecast/app/linux/server_service.py
@@ -5,23 +5,8 @@ import os, sys
 import traceback
 
 from shakecast.app.server import Server
-from shakecast.app.util import SC, get_logging_dir
+from shakecast.app.util import SC
 from shakecast.ui import UI
-
-sc = SC()
-if sc.dict['Logging']['level'] == 'info':
-    log_level = logging.INFO
-elif sc.dict['Logging']['level'] == 'debug':
-    log_level = logging.DEBUG
-
-logs_dir = get_logging_dir()
-log_file = os.path.join(logs_dir, 'sc-service.log')
-
-logging.basicConfig(
-    filename = log_file,
-    level = log_level, 
-    format = '%(asctime)s: [ShakeCast Server] %(levelname)-7.7s %(message)s')
-
 
 class ShakecastServer(object):
     _svc_name_ = "sc_server"
@@ -39,8 +24,6 @@ class ShakecastServer(object):
         ui = UI()
         if ui.server_check() is False:
             self.main()
-        else:
-            logging.info('Startup Failed -- ShakeCast Server is already started')
 
     def start_daemon(self):
         p = Process(target=self.start)
@@ -50,28 +33,15 @@ class ShakecastServer(object):
 
     @staticmethod
     def main():
-        logging.info(' ** Starting ShakeCast Server ** ')
-        try:
-            sc_server = Server()
+        sc_server = Server()
 
-            # start shakecast
-            sc_server.start_shakecast()
-            
-            while sc_server.stop_server is False:
-                sc_server.stop_loop = False
-                sc_server.loop()
+        # start shakecast
+        sc_server.start_shakecast()
+        
+        while sc_server.stop_server is False:
+            sc_server.stop_loop = False
+            sc_server.loop()
 
-        except Exception as e:
-            exc_tb = sys.exc_info()[2]
-            filename, line_num, func_name, text = traceback.extract_tb(exc_tb)[-1]
-            logging.info('{}: {} - line: {}\nOriginated: {} {} {} {}'.format(type(e), 
-                                                                             e, 
-                                                                             exc_tb.tb_lineno,
-                                                                             filename, 
-                                                                             line_num, 
-                                                                             func_name, 
-                                                                             text))
-        return
 
 def invalid():
     print '''

--- a/shakecast/app/linux/web_server_service.py
+++ b/shakecast/app/linux/web_server_service.py
@@ -1,5 +1,4 @@
 import socket
-import logging
 from multiprocessing import Process
 import os, sys
 import traceback
@@ -7,14 +6,6 @@ import urllib2
 
 from shakecast.app.util import SC, get_logging_dir
 from shakecast.web_server import start as start_web_server
-
-logs_dir = get_logging_dir()
-log_file = os.path.join(logs_dir, 'sc-web-server.log')
-logging.basicConfig(
-    filename = log_file,
-    level = logging.INFO, 
-    format = '%(asctime)s: [ShakeCast - Web] %(levelname)-7.7s %(message)s'
-)
 
 
 class ShakecastWebServer(object):
@@ -29,11 +20,10 @@ class ShakecastWebServer(object):
         # Send the http request to shutdown the server
         sc = SC()
         try:
-            logging.info('Stopping web server...')
             urllib2.urlopen('http://localhost:{}/shutdown'.format(sc.dict['web_port']))
-            logging.info('Done.')
         except Exception:
-            logging.info('Web server is not running.')
+            # web server is not running
+            pass
         
     def start(self):
         self.main()
@@ -46,22 +36,7 @@ class ShakecastWebServer(object):
 
     @staticmethod
     def main():
-        logging.info(' ** Starting ShakeCast Web Server ** ')
-        try:
-            start_web_server()
-
-        except Exception as e:
-            logging.info('FAILED')
-            exc_tb = sys.exc_info()[2]
-            filename, line_num, func_name, text = traceback.extract_tb(exc_tb)[-1]
-            logging.info('{}: {} - line: {}\nOriginated: {} {} {} {}'.format(type(e), 
-                                                                             e, 
-                                                                             exc_tb.tb_lineno,
-                                                                             filename, 
-                                                                             line_num, 
-                                                                             func_name, 
-                                                                             text))
-        return
+        start_web_server()
 
 def invalid():
     print '''

--- a/shakecast/app/notifications/notifications.py
+++ b/shakecast/app/notifications/notifications.py
@@ -175,7 +175,7 @@ def inspection_notification(notification=None,
     shakemap = notification.shakemap
     group = notification.group
 
-    logging.info('Creating inspeciton notificaiton: \nShakemap: {}-{}\nGroup:{}'
+    logging.info('Creating inspeciton notification: \nShakemap: {}-{}\nGroup:{}'
             .format(shakemap.shakemap_id, shakemap.shakemap_version, group.name))
     error = ''
 
@@ -343,13 +343,18 @@ def check_notification_for_group(group, notification, session=None, scenario=Fal
 
 
 @dbconnect
-def send_inspection_notifications(session=None):
+def inspection_notification_service(session=None):
     # grab new notifications, and any that might have failed to send
     notification = (session.query(Notification)
                         .filter(Notification.notification_type == 'DAMAGE')
                         .filter(Notification.status == 'ready')
                         .first())
 
+    notification = send_inspection_notification(notification, session)
+    return notification
+
+@dbconnect
+def send_inspection_notification(notification, session=None):
     if not notification:
         return None
 

--- a/shakecast/app/notifications/notifications.py
+++ b/shakecast/app/notifications/notifications.py
@@ -183,7 +183,7 @@ def inspection_notification(notification=None,
         group,
         notification,
         session=session,
-        scenario=scenario
+        scenario=shakemap.type == 'scenario'
     )
 
     if has_alert_level and new_inspection:
@@ -376,5 +376,5 @@ def send_inspection_notification(notification, session=None):
         logging.info('Error generation inspection notification. \n{}'.format(str(e)))
         raise
 
-    logging.info('Sent notification: {}'.format(str(notification)))
+    logging.info(str(notification))
     return notification

--- a/shakecast/app/orm/migrations.py
+++ b/shakecast/app/orm/migrations.py
@@ -173,6 +173,16 @@ def migrate_10to11(engine):
 
     return engine
 
+
+def migrate_11to12(engine):
+    update = Column('updated', Integer)
+    try:
+        add_column(engine, 'event', update)
+    except Exception:
+        pass
+
+    return engine
+
 def add_column(engine, table_name, column):
     '''
     Add a column to an existing table
@@ -190,7 +200,7 @@ def add_column(engine, table_name, column):
 # List of database migrations for export
 migrations = [migrate_1to2, migrate_2to3, migrate_3to4, migrate_4to5,
         migrate_5to6, migrate_6to7, migrate_7to8, migrate_8to9, migrate_9to10,
-        migrate_10to11]
+        migrate_10to11, migrate_11to12]
 
 def migrate(engine):
     '''

--- a/shakecast/app/orm/objects.py
+++ b/shakecast/app/orm/objects.py
@@ -704,6 +704,11 @@ class Group(Base):
         specs = self._get_specs(
             'damage', inspection=inspection, scenario=scenario)
 
+        # check for english spelling "grey"
+        if not specs and inspection == 'gray':
+            specs = self._get_specs(
+                'damage', inspection='grey', scenario=scenario)            
+
         return specs[0] if len(specs) > 0 else None
 
     def gets_notification(self, notification_type, scenario=False, heartbeat=False):

--- a/shakecast/app/orm/objects.py
+++ b/shakecast/app/orm/objects.py
@@ -850,6 +850,7 @@ class Event(Base):
     title = Column(String(100))
     place = Column(String(255))
     time = Column(Integer)
+    updated = Column(Integer)
     override_directory = Column(String(255))
 
     shakemaps = relationship('ShakeMap',

--- a/shakecast/app/orm/objects.py
+++ b/shakecast/app/orm/objects.py
@@ -460,12 +460,12 @@ class Notification(Base):
 
     def __repr__(self):
         return '''Notification(shakemap_id=%s,
-                               group_id=%s,
+                               group=%s,
                                notification_type=%s,
                                status=%s,
                                sent_timestamp=%s,
                                notification_file=%s)''' % (self.shakemap_id,
-                                                           self.group_id,
+                                                           self.group.name,
                                                            self.notification_type,
                                                            self.status,
                                                            self.sent_timestamp,

--- a/shakecast/app/productgeneration.py
+++ b/shakecast/app/productgeneration.py
@@ -1,0 +1,102 @@
+import time
+
+from .orm import dbconnect, LocalProduct, LocalProductType, Notification
+from .products.geojson import generate_impact_geojson
+import sc_logging as logging
+
+@dbconnect
+def create_products(session=None):
+    '''
+    Check for new notifications and generate products for that are still
+    missing
+    '''
+    notification = (session.query(Notification)
+            .filter(Notification.status == 'created')
+            .filter(Notification.notification_type.like('damage'))
+            .first())
+    
+    if not notification:
+        return None
+
+    notification.status = 'generating-products'
+    session.commit()
+
+    group = notification.group
+    shakemap = notification.shakemap
+
+    try:
+        # generate system level products
+        logging.info('Generating geojson product...')
+        generate_impact_geojson(shakemap, save=True)
+        logging.info('Done.')
+    except Exception as e:
+        logging.info('Error generating geojson for {}-{}: {}'
+                .format(shakemap.shakemap_id,
+                shakemap.shakemap_version,
+                str(e)))
+
+        notification.status = 'error'
+        notification.error = str(e)
+        raise
+
+    try:
+        logging.info('Generating required local products...')
+        generate_local_products(group, shakemap, session=session)
+    except Exception as e:
+        logging.info('Error generating shakemap products for {}-{}: {}'
+                .format(shakemap.shakemap_id,
+                shakemap.shakemap_version,
+                str(e)))
+
+        notification.status = 'error'
+        notification.error = str(e)
+        session.commit()
+        raise
+
+    notification.status = 'ready'
+    return notification
+    
+
+@dbconnect
+def generate_local_products(group, shakemap, session=None):
+    logging.info('Generating local products...')
+    if group.product_string is not None:
+        local_product_names = group.product_string.split(',')
+        product_types = session.query(LocalProductType).filter(
+            LocalProductType.name.in_(local_product_names)).all()
+
+        for product_type in product_types:
+            # check if product exists
+            product = (session.query(LocalProduct)
+                    .filter(LocalProduct.group == group)
+                    .filter(LocalProduct.shakemap == shakemap)
+                    .filter(LocalProduct.product_type == product_type).first())
+
+            if not product:
+                product = LocalProduct(
+                    group=group,
+                    shakemap=shakemap,
+                    product_type=product_type
+                )
+
+                product.name = (product_type.file_name or
+                        '{}_impact.{}'.format(group.name, product_type.type))
+
+            try:
+                if (product.finish_timestamp and
+                        product.finish_timestamp > product.shakemap.begin_timestamp):
+                    continue
+                
+                logging.info('Generating product: {}, for shakemap: {}-{}, for group: {}'
+                        .format(product.product_type.name, shakemap.shakemap_id, shakemap.shakemap_version, group.name))
+                product.generate()
+                logging.info('Done.')
+                product.error = None
+            except Exception as e:
+                logging.info('Product generation error: {}'.format(str(e)))
+                product.error = str(e)
+
+            logging.info('Done generating products.')
+            product.finish_timestamp = time.time()
+            session.add(product)
+        session.commit()

--- a/shakecast/app/productgeneration.py
+++ b/shakecast/app/productgeneration.py
@@ -2,7 +2,7 @@ import time
 
 from .orm import dbconnect, LocalProduct, LocalProductType, Notification
 from .products.geojson import generate_impact_geojson
-import sc_logging as logging
+from .sc_logging import server_logger as logging
 
 @dbconnect
 def create_products(session=None):

--- a/shakecast/app/productgeneration.py
+++ b/shakecast/app/productgeneration.py
@@ -5,17 +5,17 @@ from .products.geojson import generate_impact_geojson
 from .sc_logging import server_logger as logging
 
 @dbconnect
-def create_products(session=None):
+def create_products(notification=None, session=None):
     '''
     Check for new notifications and generate products for that are still
     missing
     '''
-    notification = (session.query(Notification)
+    notification = notification or (session.query(Notification)
             .filter(Notification.status == 'created')
             .filter(Notification.notification_type.like('damage'))
             .first())
     
-    if not notification:
+    if not notification or not notification.shakemap:
         return None
 
     notification.status = 'generating-products'

--- a/shakecast/app/sc_logging.py
+++ b/shakecast/app/sc_logging.py
@@ -1,5 +1,6 @@
 from functools import wraps
 import logging
+from logging.handlers import TimedRotatingFileHandler
 import os
 import time
 
@@ -22,6 +23,18 @@ logging.basicConfig(
     filename = os.path.normpath(log_path),
     level = log_level, 
     format = '%(asctime)s: [ShakeCast Server] %(levelname)-7.7s %(message)s')
+
+def get_logger(name='sc-service.log'):
+    path = os.path.join(get_logging_dir(), name)
+    logger = logging.getLogger("Rotating Log")
+    logger.setLevel(logging.INFO)
+
+    handler = TimedRotatingFileHandler(path,
+                                        when="d",
+                                        interval=1,
+                                        backupCount=7)
+    logger.addHandler(handler)
+    return logger
 
 def check_size_to_create_new():
     log_size = os.path.getsize(log_path)

--- a/shakecast/app/sc_logging.py
+++ b/shakecast/app/sc_logging.py
@@ -6,82 +6,39 @@ import time
 
 from .util import get_logging_dir, SC, DAY
 
-CURRENT_LOG_COUNT = 1
-LOG_CREATE_TIMESTAMP = 0
-MAX_LOG_SIZE = 1000000
-MAX_LOG_COUNT = 7
-
 log_dir = get_logging_dir()
-log_path = os.path.join(get_logging_dir(), 'sc-service.log')
+server_log_path = os.path.join(get_logging_dir(), 'sc-service.log')
+web_log_path = os.path.join(get_logging_dir(), 'web-server.log')
+
 sc = SC()
 if sc.dict['Logging']['level'] == 'info':
     log_level = logging.INFO
 elif sc.dict['Logging']['level'] == 'debug':
     log_level = logging.DEBUG
 
-logging.basicConfig(
-    filename = os.path.normpath(log_path),
-    level = log_level, 
-    format = '%(asctime)s: [ShakeCast Server] %(levelname)-7.7s %(message)s')
+def get_logger(name=None, path=None, level=None, format=None):
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
 
-def get_logger(name='sc-service.log'):
-    path = os.path.join(get_logging_dir(), name)
-    logger = logging.getLogger("Rotating Log")
-    logger.setLevel(logging.INFO)
-
-    handler = TimedRotatingFileHandler(path,
+    formatter = logging.Formatter('%(asctime)s: [{}] %(levelname)-7.7s %(message)s'.format(name))
+    rotating_handler = TimedRotatingFileHandler(path,
                                         when="d",
                                         interval=1,
                                         backupCount=7)
-    logger.addHandler(handler)
+
+    rotating_handler.setFormatter(formatter)
+    logger.addHandler(rotating_handler)
+
     return logger
 
-def check_size_to_create_new():
-    log_size = os.path.getsize(log_path)
-    return log_size > MAX_LOG_SIZE
+web_logger = get_logger(
+    'werkzeug',
+    web_log_path,
+    logging.WARNING
+)
 
-def move_log():
-    global CURRENT_LOG_COUNT
-
-    os.rename(log_path, '{}{}'.format(log_path, CURRENT_LOG_COUNT))
-    CURRENT_LOG_COUNT += 1
-
-    if CURRENT_LOG_COUNT > MAX_LOG_COUNT:
-        CURRENT_LOG_COUNT = 1
-
-def get_new_log():
-    '''
-    Add a new log to the logging handler
-    '''
-
-    fileh = logging.FileHandler(log_path, 'a')
-    formatter = logging.Formatter('%(asctime)s: [ShakeCast Server] %(levelname)-7.7s %(message)s')
-    fileh.setFormatter(formatter)
-
-    log = logging.getLogger()  # root logger
-    for hdlr in log.handlers[:]:  # remove all old handlers
-        log.removeHandler(hdlr)
-    log.addHandler(fileh)      # set the new handler
-
-def logging_check(func):
-    '''
-    Determine whether logs should be rolled before logging
-    '''
-
-    @wraps(func)
-    def inner(*args, **kwargs):
-        if check_size_to_create_new() is True:
-            move_log()
-            get_new_log()
-        
-        func(*args, **kwargs)
-
-    return inner
-
-@logging_check
-def info(log_str):
-    logging.info(log_str)
-
-@logging_check
-def debug(log_str):
-    logging.debug(log_str)
+server_logger = get_logger(
+    'ShakeCast Server',
+    server_log_path,
+    log_level
+)

--- a/shakecast/app/server.py
+++ b/shakecast/app/server.py
@@ -10,7 +10,7 @@ from task import Task
 import functions as f
 from util import *
 from startup import startup
-import sc_logging as logging
+from sc_logging import server_logger as logging
 
 class Server(object):
     

--- a/shakecast/app/server.py
+++ b/shakecast/app/server.py
@@ -47,7 +47,9 @@ class Server(object):
             'fast_geo_json',
             'check_new',
             'check_for_updates',
-            'record_messages'
+            'record_messages',
+            'send_notifications',
+            'create_products'
         ]
         
         sc = SC()
@@ -199,17 +201,19 @@ class Server(object):
         Check the output from a finished task and determines whether
         the task should be removed from the queue
         """
+        if task.output and type(task.output) is not dict:
+            task.output = task.output.__dict__
         if task.loop is False:
             out_str = ''
             server_log = ''
-            if task.output['status'] == 'finished':
-                out_str = task.output['message']
+            if task.output.get('status') == 'finished':
+                out_str = task.output.get('message')
                 server_log = 'Task: %s :: finished'
-            elif task.output['status'] == 'force_stop':
+            elif task.output.get('status') == 'force_stop':
                 out_str = task.output.get('message', 'No Message')
                 server_log = 'Task: %s :: force stopped'
-            elif task.output['status'] == 'failed':
-                out_str = "FAILED: %s" % task.output['message']
+            elif task.output.get('status') == 'failed':
+                out_str = "FAILED: %s" % task.output.get('message')
                 server_log = 'Task: %s :: failed to finish'
             elif task.status == 'failed':
                 out_str = '{} failed to run... \n{}: {}'.format(task.name,
@@ -233,7 +237,7 @@ class Server(object):
 
         # only log results from failed normal tasks or abnormal tasks
         if ((task.name not in self.debug_only) or
-                    task.error or (task.output and task.output['error'])):
+                    task.error or (task.output and task.output.get('error'))):
             logging.info('{}: \n\tSTATUS: {} \n\tOUTPUT: {}'.format(task.name,
                                                                     task.status,
                                                                     task.output))
@@ -347,6 +351,28 @@ class Server(object):
                 
                 self.queue += [task]
                 message += "Waiting for new events"
+
+            if 'create_products' not in task_names:
+                task = Task()
+                task.id = int(time.time() * 1000000)
+                task.func = f.create_products
+                task.loop = True
+                task.interval = 3
+                task.db_use = True
+                task.name = 'create_products'
+
+                self.queue += [task]
+
+            if 'send_notifications' not in task_names:
+                task = Task()
+                task.id = int(time.time() * 1000000)
+                task.func = f.send_inspection_notifications
+                task.loop = True
+                task.interval = 3
+                task.db_use = True
+                task.name = 'send_notifications'
+
+                self.queue += [task]
 
             if 'record_messages' not in task_names:
                 task = Task()

--- a/shakecast/app/server.py
+++ b/shakecast/app/server.py
@@ -366,7 +366,7 @@ class Server(object):
             if 'send_notifications' not in task_names:
                 task = Task()
                 task.id = int(time.time() * 1000000)
-                task.func = f.send_inspection_notifications
+                task.func = f.inspection_notification_service
                 task.loop = True
                 task.interval = 3
                 task.db_use = True

--- a/shakecast/tests/eventprocessing.py
+++ b/shakecast/tests/eventprocessing.py
@@ -5,7 +5,6 @@ import unittest
 from shakecast.app.eventprocessing import *
 from shakecast.app.grid import create_grid
 from shakecast.app.orm import (
-    clear_data,
     dbconnect,
     engine,
     Event,
@@ -64,6 +63,7 @@ class TestNewShakemap(unittest.TestCase):
         shakemap = session.query(ShakeMap).first()
 
         processed_shakemaps = process_shakemaps([shakemap], session)
+
         for shakemap in processed_shakemaps:
             self.assertNotEqual(shakemap.status, 'new')
 

--- a/shakecast/tests/eventprocessing.py
+++ b/shakecast/tests/eventprocessing.py
@@ -75,7 +75,7 @@ class TestNewShakemap(unittest.TestCase):
         session.commit()
 
         shakemap = session.query(ShakeMap).first()
-        processed_shakemaps = process_shakemaps([shakemap], session)
+        processed_shakemaps = process_shakemaps([shakemap], session=session)
         for shakemap in processed_shakemaps:
             self.assertNotEqual(shakemap.status, 'new')
 

--- a/shakecast/tests/notifications.py
+++ b/shakecast/tests/notifications.py
@@ -572,13 +572,24 @@ class TestSendInspectionNotifications(unittest.TestCase):
         preload_data()
         shakemap = session.query(ShakeMap).first()
 
+        shakemap.notifications = []
+        session.commit()
+
         process_shakemaps([shakemap], session=session, scenario=True)
-        notification = create_products(session=session)
+
+        notification = (session.query(Notification)
+                .filter(Notification.shakemap == shakemap)
+                .join(Group)
+                .filter(Group.name == 'GLOBAL_SCENARIO')
+                .first())
+
+        notification = create_products(notification=notification, session=session)
 
         self.assertIsNone(notification.error)
         self.assertEqual(notification.status, 'ready')
 
-        notification = inspection_notification_service(session=session)
+        for notification in shakemap.notifications:
+            inspection_notification_service(session=session)
 
 
 def set_email():

--- a/shakecast/tests/notifications.py
+++ b/shakecast/tests/notifications.py
@@ -2,9 +2,12 @@ import shutil
 import sys
 import unittest
 
+from shakecast.app.eventprocessing import process_shakemaps
 from shakecast.app.notifications.notifications import *
 from shakecast.app.orm import dbconnect, Facility, FacilityShaking, Group, Notification
-from util import create_group
+from shakecast.app.productgeneration import create_products
+
+from util import create_group, preload_data
 
 class TestMailer(unittest.TestCase):
     '''
@@ -561,6 +564,22 @@ class TestTemplateManager(unittest.TestCase):
         result = temp_manager.create_new(new_temp_name)
 
         self.assertTrue(result)
+
+class TestSendInspectionNotifications(unittest.TestCase):
+
+    @dbconnect
+    def test_process_Shakemap(self, session=None):
+        preload_data()
+        shakemap = session.query(ShakeMap).first()
+
+        process_shakemaps([shakemap], session)
+        notification = create_products(session=session)
+
+        self.assertIsNone(notification.error)
+        self.assertEqual(notification.status, 'ready')
+
+        notification = inspection_notification_service(session=session)
+        notification = inspection_notification_service(session=session)
 
 
 def set_email():

--- a/shakecast/tests/notifications.py
+++ b/shakecast/tests/notifications.py
@@ -572,13 +572,12 @@ class TestSendInspectionNotifications(unittest.TestCase):
         preload_data()
         shakemap = session.query(ShakeMap).first()
 
-        process_shakemaps([shakemap], session)
+        process_shakemaps([shakemap], session=session, scenario=True)
         notification = create_products(session=session)
 
         self.assertIsNone(notification.error)
         self.assertEqual(notification.status, 'ready')
 
-        notification = inspection_notification_service(session=session)
         notification = inspection_notification_service(session=session)
 
 

--- a/shakecast/tests/productgeneration.py
+++ b/shakecast/tests/productgeneration.py
@@ -1,0 +1,27 @@
+import unittest
+
+from shakecast.app.eventprocessing import process_shakemaps
+from shakecast.app.productgeneration import create_products
+from shakecast.app.orm import (
+    dbconnect,
+    ShakeMap
+)
+from shakecast.app.productdownload import grab_from_directory
+from shakecast.app.util import get_test_dir
+
+from .util import create_group, create_new_event, create_fac, preload_data
+class TestProductGeneration(unittest.TestCase):
+    @dbconnect
+    def test_process_Shakemap(self, session=None):
+        preload_data()
+        shakemap = session.query(ShakeMap).first()
+
+        process_shakemaps([shakemap], session)
+        notification = create_products(session=session)
+
+        self.assertIsNone(notification.error)
+        self.assertEqual(notification.status, 'ready')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/shakecast/tests/productgeneration.py
+++ b/shakecast/tests/productgeneration.py
@@ -10,6 +10,8 @@ from shakecast.app.productdownload import grab_from_directory
 from shakecast.app.util import get_test_dir
 
 from .util import create_group, create_new_event, create_fac, preload_data
+
+
 class TestProductGeneration(unittest.TestCase):
     @dbconnect
     def test_process_Shakemap(self, session=None):

--- a/shakecast/tests/util.py
+++ b/shakecast/tests/util.py
@@ -78,7 +78,7 @@ def create_group(name=None,
                     insp_prios=None):
 
     insp_prios = insp_prios if insp_prios else [
-        'GREY',
+        'GRAY',
         'GREEN',
         'YELLOW',
         'ORANGE',
@@ -139,10 +139,13 @@ def preload_data(session=None):
     grid = create_grid(shakemap)
     facility = create_fac(grid)
     group = create_group('GLOBAL')
-    group = create_group('GLOBAL_SCENARIO', event_type='SCENARIO')
+    group2 = create_group('GLOBAL_SCENARIO', event_type='SCENARIO')
     user = create_user()
     group.facilities += [facility]
+    group2.facilities += [facility]
     group.users += [user]
+    group2.users += [user]
 
     session.add(group)
+    session.add(group2)
     session.commit()

--- a/shakecast/tests/util.py
+++ b/shakecast/tests/util.py
@@ -139,6 +139,7 @@ def preload_data(session=None):
     grid = create_grid(shakemap)
     facility = create_fac(grid)
     group = create_group('GLOBAL')
+    group = create_group('GLOBAL_SCENARIO', event_type='SCENARIO')
     user = create_user()
     group.facilities += [facility]
     group.users += [user]

--- a/shakecast/web_server.py
+++ b/shakecast/web_server.py
@@ -48,6 +48,10 @@ app = Flask(__name__,
             template_folder=BASE_DIR,
             static_folder=STATIC_DIR)
 
+import logging
+log = logging.getLogger('werkzeug')
+log.setLevel(logging.ERROR)
+
 ################################ Login ################################
 
 app.secret_key = 'super secret key'

--- a/shakecast/web_server.py
+++ b/shakecast/web_server.py
@@ -39,6 +39,7 @@ from app.jsonencoders import AlchemyEncoder
 from app.notifications.builder import NotificationBuilder
 from app.notifications.templates import TemplateManager
 from app.orm import *
+from app.sc_logging import web_logger as log
 from app.util import SC, Clock, get_tmp_dir
 from ui import UI
 
@@ -47,10 +48,6 @@ STATIC_DIR = os.path.join(sc_dir(),'view','assets')
 app = Flask(__name__,
             template_folder=BASE_DIR,
             static_folder=STATIC_DIR)
-
-import logging
-log = logging.getLogger('werkzeug')
-log.setLevel(logging.ERROR)
 
 ################################ Login ################################
 


### PR DESCRIPTION
closes #500 
closes #496
closes #493
closes #461 (only for db server users)

Product generation and notification generation/sending are separated from default pipeline, which will allow parallel processing if using a database server. Otherwise, this is better testable and will be able to have dependent products. New model is notification based and will make shakecast compatible with auto-scaling